### PR TITLE
Lakes2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target
 .soroban
 .stellar
 
+AGENTS.md
 .agent/
 agents/
 issue.md

--- a/contracts/utility_contracts/src/ghost_sweeper.rs
+++ b/contracts/utility_contracts/src/ghost_sweeper.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{
     BytesN, Env, Symbol, Vec,
 };
 
-use crate::{ContinuousFlow, ContractError, DataKey, StreamStatus};
+use crate::{ContinuousFlow, ContractError, DataKey, StreamStatus, check_budget, validate_page_size, estimate_iteration_budget, MAX_PAGE_SIZE};
 
 /// Issue #262: Ledger Rent Sweeper for Depleted "Ghost" Devices
 /// Prunes abandoned streams after 90 days to reduce ledger footprint
@@ -205,7 +205,17 @@ impl GhostSweeper {
         let mut total_bytes_reclaimed = 0u64;
         let mut total_gas_bounty = 0i128;
 
-        for stream_id in stream_ids.iter() {
+        let num_items = stream_ids.len() as u32;
+        // Validate page size
+        let validated_limit = validate_page_size(num_items).unwrap();
+        // Check budget before starting
+        check_budget(&env, estimate_iteration_budget(validated_limit)).unwrap();
+
+        for (i, stream_id) in stream_ids.iter().enumerate() {
+            // Check budget periodically
+            if i % 10 == 0 {
+                check_budget(&env, estimate_iteration_budget(10)).unwrap();
+            }
             let bounty = Self::prune_ghost_stream(env.clone(), stream_id, relayer.clone());
             streams_pruned += 1;
             total_gas_bounty += bounty;
@@ -241,11 +251,21 @@ impl GhostSweeper {
         let mut candidates = Vec::new(&env);
         let current_time = env.ledger().timestamp();
 
+        // Validate and cap limit
+        let validated_limit = validate_page_size(limit).unwrap();
+
+        // Check budget before starting
+        check_budget(&env, estimate_iteration_budget(validated_limit)).unwrap();
+
         // This is a simplified implementation
         // In production, you would iterate through all streams or use an index
-        let stream_ids = Self::get_all_stream_ids(&env, limit);
+        let stream_ids = Self::get_all_stream_ids(&env, validated_limit);
 
-        for stream_id in stream_ids.iter() {
+        for (i, stream_id) in stream_ids.iter().enumerate() {
+            // Check budget periodically
+            if i % 10 == 0 {
+                check_budget(&env, estimate_iteration_budget(10)).unwrap();
+            }
             let stream_key = DataKey::ContinuousFlow(stream_id);
             if let Some(stream) = env
                 .storage()

--- a/contracts/utility_contracts/src/lib.rs
+++ b/contracts/utility_contracts/src/lib.rs
@@ -180,6 +180,15 @@ pub struct CreditLimitApproached {
     pub timestamp: u64,
 }
 
+#[contracttype]
+#[derive(Clone)]
+pub struct ReadingRejected {
+    pub meter_id: u64,
+    pub reason: String,
+    pub value: i128,
+    pub timestamp: u64,
+}
+
 /// Emitted when the deposit is slashed at 100 % utilisation.
 #[contracttype]
 #[derive(Clone)]
@@ -285,6 +294,15 @@ pub struct UsageReport {
 }
 
 #[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ResourceType {
+    Electricity = 0,
+    Gas = 1,
+    Water = 2,
+    Heat = 3,
+}
+
+#[contracttype]
 #[derive(Clone)]
 pub struct SignedUsageData {
     pub meter_id: u64,
@@ -333,6 +351,7 @@ pub struct Meter {
     pub user: Address,
     pub provider: Address,
     pub billing_type: BillingType,
+    pub resource_type: ResourceType,
     pub off_peak_rate: i128,
     pub peak_rate: i128,
     pub rate_per_unit: i128,
@@ -1045,6 +1064,8 @@ pub enum DataKey {
     UpgradeApproval(u64, Address),
     UpgradeProposalCounter,
     ActiveUpgradeProposalId,
+    // Meter reading validation
+    LastReadingTime(u64),
 }
 
 #[contracterror(export = false)]
@@ -1177,6 +1198,10 @@ pub enum ContractError {
     // Flow rate validation errors
     FlowRateTooLow = 111,
     FlowRateTooHigh = 112,
+    // Meter reading validation errors
+    InvalidReadingValue = 113,
+    DuplicateTimestamp = 114,
+    ReadingDeltaTooLarge = 115,
 }
 
 #[contracttype]
@@ -1289,6 +1314,14 @@ pub(crate) const STORAGE_READ_COST: u64 = 5_000; // Cost of a single storage rea
 pub(crate) const STORAGE_WRITE_COST: u64 = 5_000; // Cost of a single storage write
 pub(crate) const CONTRACT_INVOCATION_COST: u64 = 10_000; // Cost of a contract invocation
 
+// Meter reading validation constants
+const STANDARD_INTERVAL: u64 = 300; // 5 minutes in seconds
+const MAX_INTERVAL_MULTIPLIER: u64 = 24;
+const MAX_ELECTRICITY_DELTA: i128 = 100 * 1_000_000_00; // 100 kWh per 5-min interval
+const MAX_GAS_DELTA: i128 = 50 * 1_000_000_00; // 50 m³ per 5-min interval
+const MAX_WATER_DELTA: i128 = 200 * 1_000_000_00; // 200 L per 5-min interval
+const MAX_HEAT_DELTA: i128 = 100 * 1_000_000_00; // 100 units per 5-min interval
+
 /// Validate Ed25519 public key byte array
 /// Ensures correct length and non-zero values
 fn validate_ed25519_public_key(public_key: &BytesN<32>) -> Result<(), ContractError> {
@@ -1393,6 +1426,62 @@ pub(crate) fn validate_page_size(page_size: u32) -> Result<u32, ContractError> {
 pub(crate) fn estimate_iteration_budget(num_items: u32) -> u64 {
     // Budget = (storage read cost per item * num items) + (budget check cost per item * num items)
     (STORAGE_READ_COST * num_items as u64) + (BUDGET_CHECK_COST * num_items as u64)
+}
+
+/// Get maximum allowed delta for a given resource type
+fn get_max_delta(resource_type: ResourceType) -> i128 {
+    match resource_type {
+        ResourceType::Electricity => MAX_ELECTRICITY_DELTA,
+        ResourceType::Gas => MAX_GAS_DELTA,
+        ResourceType::Water => MAX_WATER_DELTA,
+        ResourceType::Heat => MAX_HEAT_DELTA,
+    }
+}
+
+/// Validate meter reading values
+fn validate_reading(
+    env: &Env,
+    meter_id: u64,
+    resource_type: ResourceType,
+    watt_hours_consumed: i128,
+    units_consumed: i128,
+    timestamp: u64,
+) -> Result<(), ContractError> {
+    // Check if value is negative
+    if watt_hours_consumed < 0 || units_consumed < 0 {
+        return Err(ContractError::InvalidReadingValue);
+    }
+
+    // Get last reading timestamp
+    let last_reading_key = DataKey::LastReadingTime(meter_id);
+    let last_reading_time: u64 = env
+        .storage()
+        .instance()
+        .get(&last_reading_key)
+        .unwrap_or(0);
+
+    // Check for duplicate or old timestamp
+    if timestamp <= last_reading_time {
+        return Err(ContractError::DuplicateTimestamp);
+    }
+
+    // Calculate time elapsed since last reading
+    let elapsed = timestamp - last_reading_time;
+
+    // Get max delta for this resource type
+    let max_delta = get_max_delta(resource_type);
+
+    // Calculate allowed maximum delta, capped at MAX_INTERVAL_MULTIPLIER * max_delta
+    let allowed_intervals = elapsed / STANDARD_INTERVAL;
+    let capped_intervals = allowed_intervals.min(MAX_INTERVAL_MULTIPLIER);
+    let allowed_delta = max_delta * capped_intervals as i128;
+
+    // Check if either watt_hours or units_consumed exceeds allowed delta
+    if watt_hours_consumed > allowed_delta || units_consumed > allowed_delta {
+        return Err(ContractError::ReadingDeltaTooLarge);
+    }
+
+    Ok(())
 }
 
 fn get_meter_or_panic(env: &Env, meter_id: u64) -> Meter {
@@ -4185,6 +4274,7 @@ impl UtilityContract {
         token: Address,
         device_public_key: BytesN<32>,
         priority_index: u32,
+        resource_type: ResourceType,
     ) -> u64 {
         Self::register_meter_with_mode(
             env,
@@ -4195,6 +4285,7 @@ impl UtilityContract {
             BillingType::PrePaid,
             device_public_key,
             priority_index,
+            resource_type,
         )
     }
 
@@ -4207,6 +4298,7 @@ impl UtilityContract {
         device_public_key: BytesN<32>,
         referrer: Address,
         priority_index: u32,
+        resource_type: ResourceType,
     ) -> u64 {
         let meter_id = Self::register_meter(
             env.clone(),
@@ -4216,6 +4308,7 @@ impl UtilityContract {
             token,
             device_public_key,
             priority_index,
+            resource_type,
         );
 
         if referrer != user {
@@ -4468,6 +4561,7 @@ impl UtilityContract {
         billing_type: BillingType,
         device_public_key: BytesN<32>,
         priority_index: u32,
+        resource_type: ResourceType,
     ) -> u64 {
         user.require_auth();
 
@@ -4495,6 +4589,7 @@ impl UtilityContract {
             user,
             provider,
             billing_type,
+            resource_type,
             off_peak_rate,
             peak_rate,
             rate_per_unit: off_peak_rate,
@@ -4751,6 +4846,35 @@ impl UtilityContract {
         validate_ed25519_signature(&signed_data.signature)?;
         validate_ed25519_public_key(&signed_data.public_key)?;
 
+        // Validate reading
+        if let Err(e) = validate_reading(
+            &env,
+            signed_data.meter_id,
+            meter.resource_type,
+            signed_data.watt_hours_consumed,
+            signed_data.units_consumed,
+            signed_data.timestamp,
+        ) {
+            // Emit ReadingRejected event
+            let reason = match e {
+                ContractError::InvalidReadingValue => String::from_str(&env, "Negative reading"),
+                ContractError::DuplicateTimestamp => String::from_str(&env, "Timestamp not after last"),
+                ContractError::ReadingDeltaTooLarge => String::from_str(&env, "Reading too large"),
+                _ => String::from_str(&env, "Unknown validation error"),
+            };
+            let event = ReadingRejected {
+                meter_id: signed_data.meter_id,
+                reason,
+                value: signed_data.units_consumed,
+                timestamp: signed_data.timestamp,
+            };
+            env.events().publish(
+                (Symbol::new(&env, "ReadReject"), signed_data.meter_id),
+                event,
+            );
+            panic_with_error!(&env, e);
+        }
+
         // Verify the signature and pairing
         if let Err(e) = verify_usage_signature(&env, &signed_data, &meter) {
             panic_with_error!(&env, e);
@@ -4947,6 +5071,11 @@ impl UtilityContract {
         // Update provider total pool
         let new_meter_value = provider_meter_value(&meter);
         update_provider_total_pool(&env, &meter.provider, old_meter_value, new_meter_value);
+
+        // Update last reading time
+        env.storage()
+            .instance()
+            .set(&DataKey::LastReadingTime(signed_data.meter_id), &signed_data.timestamp);
 
         env.storage()
             .instance()
@@ -6788,6 +6917,7 @@ impl UtilityContract {
         token: Address,
         device_public_key: BytesN<32>,
         priority_index: u32,
+        resource_type: ResourceType,
     ) -> u64 {
         // Verify caller is a configured Sub-DAO
         let sub_dao = env.current_contract_address();
@@ -6822,6 +6952,7 @@ impl UtilityContract {
             BillingType::PrePaid,
             device_public_key,
             priority_index,
+            resource_type,
         );
 
         // Update spent budget (simplified)

--- a/contracts/utility_contracts/src/lib.rs
+++ b/contracts/utility_contracts/src/lib.rs
@@ -1171,6 +1171,12 @@ pub enum ContractError {
     UpgradeProposalExpired = 106,
     NotAuthorizedUpgradeSigner = 107,
     InsufficientUpgradeApprovals = 108,
+    // Budget and paging errors
+    BudgetExceeded = 109,
+    PageSizeExceeded = 110,
+    // Flow rate validation errors
+    FlowRateTooLow = 111,
+    FlowRateTooHigh = 112,
 }
 
 #[contracttype]
@@ -1273,6 +1279,16 @@ const ED25519_SIGNATURE_SIZE: usize = 64;
 const SHA256_HASH_SIZE: usize = 32;
 const MAX_BYTE_ARRAY_SIZE: usize = 1024; // Maximum reasonable size for user inputs
 
+// Budget and paging constants
+pub(crate) const MAX_CONTRACT_INSTRUCTIONS: u64 = 1_000_000; // 1M instructions per contract call
+pub(crate) const MIN_REMAINING: u64 = 100_000; // Minimum remaining instructions before stopping
+pub(crate) const MAX_PAGE_SIZE: u32 = 100; // Maximum number of items per page
+pub(crate) const DEFAULT_PAGE_SIZE: u32 = 20; // Default page size
+pub(crate) const BUDGET_CHECK_COST: u64 = 500; // Cost of a single budget check
+pub(crate) const STORAGE_READ_COST: u64 = 5_000; // Cost of a single storage read
+pub(crate) const STORAGE_WRITE_COST: u64 = 5_000; // Cost of a single storage write
+pub(crate) const CONTRACT_INVOCATION_COST: u64 = 10_000; // Cost of a contract invocation
+
 /// Validate Ed25519 public key byte array
 /// Ensures correct length and non-zero values
 fn validate_ed25519_public_key(public_key: &BytesN<32>) -> Result<(), ContractError> {
@@ -1351,6 +1367,32 @@ fn validate_hourly_flow_rate(hourly_rate: i128) -> Result<(), ContractError> {
     }
 
     Ok(())
+}
+
+/// Check if remaining budget is sufficient for required instructions
+pub(crate) fn check_budget(env: &Env, required: u64) -> Result<(), ContractError> {
+    let remaining = env.budget().get_remaining_instructions();
+    if remaining < required {
+        return Err(ContractError::BudgetExceeded);
+    }
+    Ok(())
+}
+
+/// Validate page size is within allowed limits
+pub(crate) fn validate_page_size(page_size: u32) -> Result<u32, ContractError> {
+    if page_size == 0 {
+        Ok(DEFAULT_PAGE_SIZE)
+    } else if page_size > MAX_PAGE_SIZE {
+        Err(ContractError::PageSizeExceeded)
+    } else {
+        Ok(page_size)
+    }
+}
+
+/// Estimate required budget for iterating over N storage items
+pub(crate) fn estimate_iteration_budget(num_items: u32) -> u64 {
+    // Budget = (storage read cost per item * num items) + (budget check cost per item * num items)
+    (STORAGE_READ_COST * num_items as u64) + (BUDGET_CHECK_COST * num_items as u64)
 }
 
 fn get_meter_or_panic(env: &Env, meter_id: u64) -> Meter {


### PR DESCRIPTION
closes #21
---
Okay, here's a PR message you can use! It clearly explains what was added and what was fixed:

---

**Title**: Add meter reading validation

**Description**:
This PR adds meter reading validation logic to the utility contracts, including:

- `ReadingRejected` event: Emitted when a reading fails validation
- `ResourceType` enum: Defines supported resource types (Electricity, Gas, Water, Heat)
- `Meter` struct now includes `resource_type` to track which resource a meter measures
- New contract errors for reading validation:
  - `InvalidReadingValue`: For negative watt-hours or units consumed
  - `DuplicateTimestamp`: For readings that are not after the last reading's timestamp
  - `ReadingDeltaTooLarge`: For readings that exceed the maximum allowed delta for their resource type
- Reading validation helpers:
  - `get_max_delta`: Gets the maximum allowed delta for a resource type
  - `validate_reading`: Performs the validation checks
- Updated all meter creation functions (`register_meter`, `register_meter_with_mode`, `register_with_referral`, `create_sub_dao_stream`) to accept and initialize `resource_type`
- Integrated reading validation into the usage submission flow (emits `ReadingRejected` on failure)
- Stores last reading time per meter

---

Make sure to include any additional context or testing notes you think are relevant!