### PR TITLE
fix(settlement): reject stale oracle prices with conservative fallback

### DIFF
--- a/contracts/settlement/src/constants.rs
+++ b/contracts/settlement/src/constants.rs
@@ -30,3 +30,33 @@ pub const MAX_RATE: i128 = 10_000_000_000_000; // 1_000_000 * 1e7
 
 /// Denominator for fixed-point operations (7 decimal places)
 pub const DECIMAL_DENOMINATOR: i128 = 10_000_000; // 1e7
+
+// --- Oracle staleness protection (issue #7) ------------------------------
+
+/// Maximum age (in epoch-seconds) of an oracle price before it is considered
+/// stale. Compared against `env.ledger().timestamp()`.
+///
+/// Must lie within `[300, 3600]` (5 minutes .. 1 hour); enforced at compile
+/// time below.
+pub const MAX_ORACLE_AGE: u64 = 600; // 10 minutes
+
+/// Lower bound for [`MAX_ORACLE_AGE`] (5 minutes).
+pub const MIN_ORACLE_AGE_BOUND: u64 = 300;
+/// Upper bound for [`MAX_ORACLE_AGE`] (1 hour).
+pub const MAX_ORACLE_AGE_BOUND: u64 = 3600;
+
+// Compile-time guarantee that the configured staleness window is in range.
+const _: () = assert!(
+    MAX_ORACLE_AGE >= MIN_ORACLE_AGE_BOUND && MAX_ORACLE_AGE <= MAX_ORACLE_AGE_BOUND,
+    "MAX_ORACLE_AGE must be within [300, 3600] seconds"
+);
+
+/// Conservative fallback rate used when the oracle price is stale.
+/// `50_000_000` in 7-decimal fixed point (= 5.0), per issue #7 step 1.
+pub const FALLBACK_RATE: i128 = 50_000_000;
+
+/// Maximum allowable relative deviation of the computed rate from the true rate,
+/// `0.001 * 1e7` in 7-decimal fixed point (i.e. 0.1%). Used as the tolerance
+/// bound documented by the staleness invariant.
+#[allow(dead_code)]
+pub const MAX_STALENESS_TOLERANCE: i128 = 10_000;

--- a/contracts/settlement/src/conversion.rs
+++ b/contracts/settlement/src/conversion.rs
@@ -1,34 +1,32 @@
-use soroban_sdk::{panic_with_error, Address, Env};
+use soroban_sdk::{panic_with_error, Env};
 
-use crate::constants::{BPS_DENOMINATOR, DECIMAL_DENOMINATOR, MAX_SLIPPAGE_BPS};
-use crate::rate_application::get_rate;
+use crate::constants::{BPS_DENOMINATOR, MAX_SLIPPAGE_BPS};
+use crate::rate_application::apply_rate_to_volume;
 use crate::SettlementError;
 
-/// Convert resource token volume to settlement currency using the oracle exchange rate.
+/// Convert resource token volume to settlement currency using the supplied
+/// (already staleness-resolved) exchange rate.
+///
+/// The `rate` is resolved by the caller via
+/// [`crate::rate_application::resolve_rate`], so a stale oracle has already been
+/// replaced by the conservative fallback before reaching this function.
 ///
 /// Flow:
-/// 1. Fetches the current oracle rate
-/// 2. Computes the settlement amount = volume * rate / 1e7
-/// 3. Checks actual amount against slippage tolerance and user's minimum
+/// 1. Computes the settlement amount = volume * rate / 1e7
+/// 2. Checks actual amount against slippage tolerance and user's minimum
 ///
 /// # Returns
-/// The settlement amount computed from the oracle rate
+/// The settlement amount computed from the resolved rate
 ///
 /// # Panics
 /// * `SlippageExceeded` if slippage exceeds MAX_SLIPPAGE_BPS or actual < min_expected_amount
 pub fn convert_to_settlement_currency(
     env: &Env,
-    oracle: &Address,
+    rate: i128,
     volume: i128,
     min_expected_amount: Option<i128>,
 ) -> i128 {
-    let rate = get_rate(env, oracle);
-
-    let expected_amount = volume
-        .checked_mul(rate)
-        .expect("conversion overflow")
-        .checked_div(DECIMAL_DENOMINATOR)
-        .expect("conversion underflow");
+    let expected_amount = apply_rate_to_volume(volume, rate);
 
     let actual_amount = expected_amount;
 

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -7,7 +7,10 @@ mod rate_application;
 mod token_utils;
 mod types;
 
-use soroban_sdk::{contract, contractclient, contracterror, contractimpl, panic_with_error, Address, Env};
+use soroban_sdk::{
+    contract, contractclient, contracterror, contractimpl, contracttype, panic_with_error, Address,
+    Env,
+};
 
 #[cfg(test)]
 mod test;
@@ -15,13 +18,32 @@ mod test;
 use crate::constants::MAX_FEE_RATE_BPS;
 use crate::conversion::convert_to_settlement_currency;
 use crate::fees::compute_fee;
+use crate::rate_application::resolve_rate;
 use crate::token_utils::collect_fee;
 use crate::types::{SettlementArgs, SettlementResult};
+
+/// Oracle price snapshot. Layout mirrors the `price_oracle` contract's
+/// `PriceData` (field names/types match) so it deserializes from that oracle's
+/// `get_price()` response across the cross-contract boundary.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OraclePrice {
+    /// Price in 7-decimal fixed point.
+    pub price: i128,
+    /// Number of decimal places the price is expressed in.
+    pub decimals: u32,
+    /// Ledger timestamp (epoch-seconds) at which the price was last updated.
+    pub last_updated: u64,
+}
 
 /// Cross-contract interface for the PriceOracle.
 #[contractclient(name = "PriceOracleClient")]
 pub trait PriceOracle {
+    /// Raw price value (7-decimal fixed point).
     fn get_price_value(env: Env) -> i128;
+    /// Full price snapshot including the `last_updated` timestamp used for
+    /// staleness checks.
+    fn get_price(env: Env) -> OraclePrice;
 }
 
 #[contracterror]
@@ -31,6 +53,8 @@ pub enum SettlementError {
     InvalidFeeRate = 1,
     InsufficientBalance = 2,
     SlippageExceeded = 3,
+    /// The oracle price is older than `MAX_ORACLE_AGE` (stale feed).
+    OracleStale = 4,
 }
 
 #[contract]
@@ -124,14 +148,15 @@ impl SettlementContract {
 
         payer.require_auth();
 
-        let rate = {
-            let oracle_client = PriceOracleClient::new(&env, &oracle);
-            oracle_client.get_price_value()
-        };
+        // Resolve the exchange rate with staleness protection: a fresh oracle
+        // price is used directly; a stale feed is rejected and replaced by the
+        // conservative FALLBACK_RATE (emitting a StaleFbk event). `rate` is the
+        // rate actually applied, reported back as `rate_used`.
+        let rate = resolve_rate(&env, &oracle);
 
         let settlement_amount = convert_to_settlement_currency(
             &env,
-            &oracle,
+            rate,
             args.volume,
             args.min_expected_amount,
         );

--- a/contracts/settlement/src/rate_application.rs
+++ b/contracts/settlement/src/rate_application.rs
@@ -1,10 +1,81 @@
-use soroban_sdk::{Address, Env};
+//! Oracle rate fetching with staleness protection (issue #7).
+//!
+//! The settlement contract prices resource volume using an external price-feed
+//! oracle. If that feed goes stale (its `last_updated` falls further behind the
+//! ledger clock than [`MAX_ORACLE_AGE`]), continuing to use the old price lets an
+//! attacker accumulate under-priced settlements during the stale window.
+//!
+//! This module reads the *authoritative* `last_updated` from the oracle's own
+//! `get_price()` response (rather than caching oracle metadata locally), rejects
+//! prices older than the staleness window, and substitutes a conservative
+//! [`FALLBACK_RATE`] — emitting a `StaleFbk` event so the fallback is observable.
+//! A strict, `Result`-returning variant ([`get_fresh_rate`]) is provided for
+//! callers that prefer to abort rather than fall back.
 
-use crate::PriceOracleClient;
+use soroban_sdk::{symbol_short, Address, Env};
 
-/// Fetch the current exchange rate from the price oracle.
-/// Returns the rate as an i128 with 7 decimal places.
-pub fn get_rate(env: &Env, oracle: &Address) -> i128 {
+use crate::constants::{DECIMAL_DENOMINATOR, FALLBACK_RATE, MAX_ORACLE_AGE};
+use crate::{PriceOracleClient, SettlementError};
+
+/// Whether a price stamped at `last_updated` is stale relative to `now`.
+///
+/// Staleness is `age > MAX_ORACLE_AGE`; a price exactly `MAX_ORACLE_AGE` seconds
+/// old is still considered fresh (boundary is inclusive of "fresh"). Uses
+/// saturating subtraction so a `last_updated` in the (clock-skewed) future is
+/// treated as age 0 / fresh rather than underflowing.
+pub fn is_stale(now: u64, last_updated: u64) -> bool {
+    now.saturating_sub(last_updated) > MAX_ORACLE_AGE
+}
+
+/// The conservative rate used when the oracle price is stale.
+pub fn compute_fallback_rate() -> i128 {
+    FALLBACK_RATE
+}
+
+/// Apply a 7-decimal fixed-point `rate` to `volume`: `volume * rate / 1e7`.
+/// Overflow-checked.
+pub fn apply_rate_to_volume(volume: i128, rate: i128) -> i128 {
+    volume
+        .checked_mul(rate)
+        .expect("rate application overflow")
+        .checked_div(DECIMAL_DENOMINATOR)
+        .expect("rate application underflow")
+}
+
+/// Fetch the current oracle rate, **rejecting** stale data.
+///
+/// Returns `Err(SettlementError::OracleStale)` if the oracle's price is older
+/// than [`MAX_ORACLE_AGE`]. This is the strict, halt-on-stale variant referenced
+/// by issue #7 step 7 (propagate a `Result` instead of panicking).
+pub fn get_fresh_rate(env: &Env, oracle: &Address) -> Result<i128, SettlementError> {
     let client = PriceOracleClient::new(env, oracle);
-    client.get_price_value()
+    let price = client.get_price();
+
+    if is_stale(env.ledger().timestamp(), price.last_updated) {
+        return Err(SettlementError::OracleStale);
+    }
+
+    Ok(price.price)
+}
+
+/// Resolve the rate to use for settlement: the fresh oracle price when
+/// available, otherwise the conservative [`FALLBACK_RATE`].
+///
+/// On fallback a `StaleFbk` event `(now, last_updated, fallback_rate)` is emitted
+/// so downstream monitors can detect that the stale-price protection engaged.
+pub fn resolve_rate(env: &Env, oracle: &Address) -> i128 {
+    let client = PriceOracleClient::new(env, oracle);
+    let price = client.get_price();
+    let now = env.ledger().timestamp();
+
+    if is_stale(now, price.last_updated) {
+        let fallback = compute_fallback_rate();
+        env.events().publish(
+            (symbol_short!("StaleFbk"),),
+            (now, price.last_updated, fallback),
+        );
+        fallback
+    } else {
+        price.price
+    }
 }

--- a/contracts/settlement/src/test.rs
+++ b/contracts/settlement/src/test.rs
@@ -167,17 +167,18 @@ fn test_randomized_properties() {
     }
 }
 
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Ledger};
 use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
 
-use crate::constants::DECIMAL_DENOMINATOR;
+use crate::constants::{DECIMAL_DENOMINATOR, FALLBACK_RATE, MAX_ORACLE_AGE};
 use crate::types::SettlementArgs;
-use crate::{SettlementContract, SettlementContractClient};
+use crate::{OraclePrice, SettlementContract, SettlementContractClient};
 
 #[contracttype]
 #[derive(Clone)]
 enum OracleDataKey {
     Price,
+    Updated,
 }
 
 #[contract]
@@ -187,6 +188,8 @@ struct MockOracle;
 impl MockOracle {
     pub fn initialize(env: Env, _admin: Address, _updater: Address, initial_price: i128, _decimals: u32) {
         env.storage().instance().set(&OracleDataKey::Price, &initial_price);
+        let now = env.ledger().timestamp();
+        env.storage().instance().set(&OracleDataKey::Updated, &now);
     }
 
     pub fn get_price_value(env: Env) -> i128 {
@@ -194,6 +197,21 @@ impl MockOracle {
             .instance()
             .get(&OracleDataKey::Price)
             .unwrap_or(0)
+    }
+
+    /// Full snapshot consumed by the settlement staleness check.
+    pub fn get_price(env: Env) -> OraclePrice {
+        OraclePrice {
+            price: env.storage().instance().get(&OracleDataKey::Price).unwrap_or(0),
+            decimals: 7,
+            last_updated: env.storage().instance().get(&OracleDataKey::Updated).unwrap_or(0),
+        }
+    }
+
+    /// Test helper: override the price's last-updated timestamp to simulate a
+    /// stale (or freshly-updated) feed.
+    pub fn set_updated(env: Env, ts: u64) {
+        env.storage().instance().set(&OracleDataKey::Updated, &ts);
     }
 }
 
@@ -349,4 +367,146 @@ fn test_user_min_expected_amount_higher_than_actual_fails() {
     }));
 
     assert!(result.is_err());
+}
+
+// --- Oracle staleness protection (issue #7) ------------------------------
+
+/// Pure unit tests for the staleness predicate and rate application.
+mod staleness_unit {
+    use crate::constants::{
+        DECIMAL_DENOMINATOR, FALLBACK_RATE, MAX_ORACLE_AGE, MAX_ORACLE_AGE_BOUND,
+        MIN_ORACLE_AGE_BOUND,
+    };
+    use crate::rate_application::{apply_rate_to_volume, compute_fallback_rate, is_stale};
+
+    #[test]
+    fn test_max_oracle_age_within_bounds() {
+        assert!(MAX_ORACLE_AGE >= MIN_ORACLE_AGE_BOUND);
+        assert!(MAX_ORACLE_AGE <= MAX_ORACLE_AGE_BOUND);
+    }
+
+    #[test]
+    fn test_is_stale_boundary() {
+        let updated = 1_000u64;
+        // age == MAX_ORACLE_AGE -> still fresh.
+        assert!(!is_stale(updated + MAX_ORACLE_AGE, updated));
+        // age == MAX_ORACLE_AGE + 1 -> stale.
+        assert!(is_stale(updated + MAX_ORACLE_AGE + 1, updated));
+        // clock skew (updated in the future) -> treated as fresh, no underflow.
+        assert!(!is_stale(updated, updated + 50));
+    }
+
+    #[test]
+    fn test_apply_rate_to_volume() {
+        // volume * rate / 1e7
+        assert_eq!(apply_rate_to_volume(1_000_0000, FALLBACK_RATE), 5_000_000);
+        assert_eq!(apply_rate_to_volume(0, FALLBACK_RATE), 0);
+        assert_eq!(
+            apply_rate_to_volume(DECIMAL_DENOMINATOR, DECIMAL_DENOMINATOR),
+            DECIMAL_DENOMINATOR
+        );
+    }
+
+    #[test]
+    fn test_compute_fallback_rate() {
+        assert_eq!(compute_fallback_rate(), FALLBACK_RATE);
+    }
+}
+
+#[test]
+fn test_fresh_oracle_under_threshold_uses_oracle_rate() {
+    // Fresh feed (age 0) -> the oracle price is used directly.
+    let (env, oracle_id, _admin, payer, payee, fee_collector) = setup_env();
+    let settlement_id = setup_settlement(&env);
+    let settlement_client = SettlementContractClient::new(&env, &settlement_id);
+
+    let rate = 100_000_0000i128;
+    let volume = 1_000_0000i128;
+    let token_id = setup_token(&env, &payer, settlement_amount(volume, rate));
+
+    let args = make_args(token_id, volume, payee.clone(), None);
+
+    let result =
+        settlement_client.finalize_settlement(&oracle_id, &payer, &fee_collector, &args, &100u32);
+
+    assert_eq!(result.rate_used, rate);
+    assert!(result.net_amount > 0);
+}
+
+#[test]
+fn test_fresh_oracle_at_boundary_uses_oracle_rate() {
+    // Age exactly MAX_ORACLE_AGE -> still fresh -> oracle price used.
+    let (env, oracle_id, _admin, payer, payee, fee_collector) = setup_env();
+    let settlement_id = setup_settlement(&env);
+    let settlement_client = SettlementContractClient::new(&env, &settlement_id);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+
+    let rate = 100_000_0000i128;
+    let volume = 1_000_0000i128;
+    let token_id = setup_token(&env, &payer, settlement_amount(volume, rate));
+
+    // Price stamped at t=0; advance the ledger to exactly MAX_ORACLE_AGE.
+    oracle_client.set_updated(&0u64);
+    env.ledger().set_timestamp(MAX_ORACLE_AGE);
+
+    let args = make_args(token_id, volume, payee.clone(), None);
+    let result =
+        settlement_client.finalize_settlement(&oracle_id, &payer, &fee_collector, &args, &100u32);
+
+    assert_eq!(result.rate_used, rate, "boundary age must be treated as fresh");
+}
+
+#[test]
+fn test_stale_oracle_falls_back_to_conservative_rate() {
+    // Feed older than MAX_ORACLE_AGE -> stale price rejected, FALLBACK_RATE used.
+    let (env, oracle_id, _admin, payer, payee, fee_collector) = setup_env();
+    let settlement_id = setup_settlement(&env);
+    let settlement_client = SettlementContractClient::new(&env, &settlement_id);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+
+    let volume = 1_000_0000i128;
+    // Fund generously: settlement uses the (smaller) fallback rate.
+    let token_id = setup_token(&env, &payer, 1_000_000_000i128);
+
+    // Price stamped at t=0; push the clock one second past the staleness window.
+    oracle_client.set_updated(&0u64);
+    env.ledger().set_timestamp(MAX_ORACLE_AGE + 1);
+
+    let args = make_args(token_id, volume, payee.clone(), None);
+    let result =
+        settlement_client.finalize_settlement(&oracle_id, &payer, &fee_collector, &args, &100u32);
+
+    assert_eq!(
+        result.rate_used, FALLBACK_RATE,
+        "stale oracle must fall back to the conservative rate"
+    );
+    // Settlement amount reflects the fallback rate, not the stale oracle price.
+    let expected_settlement = volume * FALLBACK_RATE / DECIMAL_DENOMINATOR;
+    let expected_fee = crate::fees::compute_fee(expected_settlement, 100);
+    assert_eq!(result.fee_amount, expected_fee);
+    assert_eq!(result.net_amount, expected_settlement - expected_fee);
+}
+
+#[test]
+fn test_get_fresh_rate_rejects_stale_feed() {
+    // The strict, Result-returning variant (issue #7 step 7): Ok when fresh,
+    // Err(OracleStale) when stale — no fallback.
+    let (env, oracle_id, _admin, _payer, _payee, _fee_collector) = setup_env();
+    let settlement_id = setup_settlement(&env);
+    let oracle_client = MockOracleClient::new(&env, &oracle_id);
+    oracle_client.set_updated(&0u64);
+
+    // Fresh.
+    env.ledger().set_timestamp(MAX_ORACLE_AGE);
+    let fresh = env.as_contract(&settlement_id, || {
+        crate::rate_application::get_fresh_rate(&env, &oracle_id)
+    });
+    assert_eq!(fresh, Ok(100_000_0000i128));
+
+    // Stale.
+    env.ledger().set_timestamp(MAX_ORACLE_AGE + 1);
+    let stale = env.as_contract(&settlement_id, || {
+        crate::rate_application::get_fresh_rate(&env, &oracle_id)
+    });
+    assert_eq!(stale, Err(crate::SettlementError::OracleStale));
 }


### PR DESCRIPTION
# fix(settlement): reject stale oracle prices with conservative fallback

Closes #7

- **`constants.rs`**
  - `MAX_ORACLE_AGE = 600` (epoch-seconds), **compile-time enforced** to be within
    `[300, 3600]` via a `const _: () = assert!(…)`.
  - `FALLBACK_RATE = 50_000_000` (7-decimal fixed point), `MAX_STALENESS_TOLERANCE`.
- **`rate_application.rs`**
  - `is_stale(now, last_updated)` — stale ⇔ `age > MAX_ORACLE_AGE` (boundary age is
    fresh; saturating sub tolerates clock skew).
  - `apply_rate_to_volume(volume, rate)` — overflow-checked `volume * rate / 1e7`.
  - `resolve_rate(env, oracle)` — fresh oracle price, else conservative
    `FALLBACK_RATE` with a `StaleFbk(now, last_updated, fallback)` event.
  - `get_fresh_rate(env, oracle) -> Result<i128, SettlementError>` — strict,
    halt-on-stale variant (step 7: propagate a `Result` instead of panicking).
- **`lib.rs`**
  - Extend the `PriceOracle` cross-contract interface with
    `get_price() -> OraclePrice`, an XDR-compatible mirror of
    `price_oracle::PriceData` (incl. `last_updated`).
  - Add `SettlementError::OracleStale`.
  - `finalize_settlement` now uses `resolve_rate`, so `rate_used` reflects the rate
    actually applied (fresh price or fallback).
- **`conversion.rs`** — `convert_to_settlement_currency` takes the already-resolved
  `rate` as a parameter (single source of truth; no double oracle fetch).

## Files
- `contracts/settlement/src/constants.rs`
- `contracts/settlement/src/rate_application.rs`
- `contracts/settlement/src/conversion.rs`
- `contracts/settlement/src/lib.rs`
- `contracts/settlement/src/test.rs`
