### PR TITLE
Code coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Run tests
         run: cargo test
+      - name: Install coverage tooling
+        run: cargo install cargo-llvm-cov --locked
+      - name: Enforce coverage threshold
+        env:
+          COVERAGE_THRESHOLD: 80
+        run: scripts/coverage.sh
       - name: Fuzz test detection
         run: |
           if [ -d "contracts/utility_contracts/fuzz" ]; then

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ cd contracts && cargo build --target wasm32-unknown-unknown --release
 # Test
 cargo test
 
+# Coverage (requires cargo-llvm-cov)
+COVERAGE_THRESHOLD=80 scripts/coverage.sh
+
 # Lint
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
@@ -115,7 +118,8 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) automatically runs on:
 2. **Code Quality**: `cargo fmt --all -- --check` + `cargo clippy --target wasm32-unknown-unknown -- -D warnings`
 3. **Build**: `cargo build --target wasm32-unknown-unknown --release`
 4. **Unit Tests**: `cargo test` including fuzz tests
-5. **Fuzz Tests**: Auto-detection and validation of fuzz infrastructure
+5. **Coverage Gate**: `scripts/coverage.sh` enforces the configured line coverage threshold (`COVERAGE_THRESHOLD`, default 80%) for both the root package and contracts workspace
+6. **Fuzz Tests**: Auto-detection and validation of fuzz infrastructure
 
 ### Local Development
 
@@ -124,6 +128,7 @@ cargo fmt --all -- --check
 cargo clippy --target wasm32-unknown-unknown -- -D warnings
 cargo build --target wasm32-unknown-unknown --release
 cargo test
+COVERAGE_THRESHOLD=80 scripts/coverage.sh
 ```
 
 ## ZK-SNARK Circuits for Sensor Privacy

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COVERAGE_THRESHOLD="${COVERAGE_THRESHOLD:-80}"
+CARGO_LLVM_COV_FLAGS=(--locked --all-features --workspace --fail-under-lines "${COVERAGE_THRESHOLD}")
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+  echo "cargo-llvm-cov is required. Install it with: cargo install cargo-llvm-cov --locked"
+  exit 127
+fi
+
+echo "Enforcing line coverage threshold: ${COVERAGE_THRESHOLD}%"
+
+echo "::group::Root package coverage"
+cargo llvm-cov "${CARGO_LLVM_COV_FLAGS[@]}"
+echo "::endgroup::"
+
+echo "::group::Contracts workspace coverage"
+cargo llvm-cov --manifest-path contracts/Cargo.toml "${CARGO_LLVM_COV_FLAGS[@]}"
+echo "::endgroup::"


### PR DESCRIPTION
Motivation
Prevent regressions by enforcing a workspace line coverage minimum in CI across all Rust contracts and packages.
Provide a reusable, configurable gate that CI and contributors can run locally to verify coverage thresholds.
Description
Add scripts/coverage.sh, a small wrapper that requires cargo-llvm-cov, reads COVERAGE_THRESHOLD (default 80), and runs cargo llvm-cov for the root package and the contracts workspace.
Update .github/workflows/ci.yml to install cargo-llvm-cov and run the coverage gate after cargo test with COVERAGE_THRESHOLD: 80.
Update README.md to document local usage (COVERAGE_THRESHOLD=80 scripts/coverage.sh) and to list the new coverage gate in the CI testing stages.
Testing
Ran bash -n scripts/coverage.sh to validate script syntax and it succeeded.
Ran formatting and unit tests with cargo fmt --all -- --check and cargo test, both of which completed successfully in the environment used for validation.
Verified that local coverage execution was skipped when cargo-llvm-cov was not present locally and that CI will install cargo-llvm-cov before running the gate.
Ran git diff --check to confirm no whitespace or diff errors were introduced.
Closes https://github.com/Utility-Protocol/Utility-contracts/issues/85